### PR TITLE
Bug Fix

### DIFF
--- a/cambd/cambd.py
+++ b/cambd/cambd.py
@@ -206,6 +206,16 @@ def main(word: str, show_all: bool, verbose: bool, dictionary: str):
             definitions,
         )
     )
+    if len(wanted_definitions) == 0:
+        spinner.warn(f"No word found in the {dictionary} dictionary."
+                      " Grabbing from all.")
+        wanted_definitions = list(
+            filter(
+                lambda want: want["DictionaryRegion"].lower() in ['us', 'uk'],
+                definitions,
+            )
+        )
+
     if not show_all:
         print_definition(word_filtered, wanted_definitions[0], True, verbose)
     else:

--- a/cambd/cambd.py
+++ b/cambd/cambd.py
@@ -206,12 +206,15 @@ def main(word: str, show_all: bool, verbose: bool, dictionary: str):
             definitions,
         )
     )
+
+    # If no definition found in the selected dictionary, grab from all
     if len(wanted_definitions) == 0:
-        spinner.warn(f"No word found in the {dictionary} dictionary."
-                      " Grabbing from all.")
+        spinner.warn(
+            f"No word found in the {dictionary} dictionary." " Grabbing from all."
+        )
         wanted_definitions = list(
             filter(
-                lambda want: want["DictionaryRegion"].lower() in ['us', 'uk'],
+                lambda want: want["DictionaryRegion"].lower() in ["us", "uk"],
                 definitions,
             )
         )


### PR DESCRIPTION
Fixes #28.
Ran a debugger on it and found that the run time error is cause when the only definition found is in the **other dictionary**. The word _sappy_ is only found in the US range, but the default is UK.